### PR TITLE
fix #61: resolve MVVM binding chain past inherited generic getters

### DIFF
--- a/doc/data_binding_navigation_completion.md
+++ b/doc/data_binding_navigation_completion.md
@@ -58,4 +58,25 @@ When a multi-segment chain is encountered (e.g., `vm.user.name`), the plugin res
 *   `user` → `User` class (via `MyViewModel.getUser()`)
 *   `name` → suggestion from `User` class
 
+#### Generic type substitution
+
+Getters are frequently inherited from a generic base class. To resolve the chain past
+such a getter, the plugin substitutes type parameters along the inheritance chain rather
+than reading the raw declared return type. For example:
+
+```
+class CrewModel        { String getName(); }
+abstract class GenericVM<T> { T getModel(); }   // getter declared on the generic base
+class CrewVM extends GenericVM<CrewModel> { }   // binds T = CrewModel
+```
+
+For `vm.model.name`, `getModel()` declares the return type as the type variable `T`.
+`ZulDomUtil.substituteReturnType(owner, ownerSubstitutor, method)` maps `T` to the type
+argument bound by the concrete ViewModel (`CrewModel`) using
+`TypeConversionUtil.getSuperClassSubstitutor`, and `ZulDomUtil.substitutorOf(type)` carries
+the resulting substitutor to the next segment so deeper generic chains keep resolving. Both
+`ZkBindingReferenceProvider` (navigation/highlighting) and the `ZulDomUtil` chain walkers
+(collection element / model type inference) use this path. The substitution falls back to
+the raw return type if the hierarchy cannot be analysed, so resolution never regresses.
+
 For more details, see the original implementation notes in the respective feature files.

--- a/src/main/java/org/zkoss/zkidea/dom/ZulDomUtil.java
+++ b/src/main/java/org/zkoss/zkidea/dom/ZulDomUtil.java
@@ -25,11 +25,14 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiModifier;
+import com.intellij.psi.PsiSubstitutor;
 import com.intellij.psi.PsiType;
 import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.util.TypeConversionUtil;
 import com.intellij.psi.xml.XmlAttribute;
 import com.intellij.psi.xml.XmlFile;
 import com.intellij.psi.xml.XmlTag;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.zkoss.zkidea.lang.ZulFileType;
 
@@ -395,13 +398,18 @@ public class ZulDomUtil {
 		if (segments.length < 2 || !segments[0].equals(vmId) || vmClass == null) return null;
 
 		PsiClass currentClass = vmClass;
+		PsiSubstitutor currentSubst = PsiSubstitutor.EMPTY;
 		PsiType lastType = null;
 		for (int i = 1; i < segments.length; i++) {
 			PsiMethod getter = findGetter(currentClass, segments[i]);
 			if (getter == null) return null;
-			lastType = getter.getReturnType();
+			// Resolve the getter's return type through the receiver's type arguments so
+			// that a generic type inherited from a generic base (e.g. List<T> declared in
+			// GenericVM<T>) is seen with T bound to the concrete type argument.
+			lastType = substituteReturnType(currentClass, currentSubst, getter);
 			if (lastType == null) return null;
 			if (i < segments.length - 1) {
+				currentSubst = substitutorOf(lastType);
 				currentClass = resolveTypeToClass(lastType, context);
 				if (currentClass == null) return null;
 			}
@@ -436,11 +444,13 @@ public class ZulDomUtil {
 		if (segments.length < 2 || !segments[0].equals(vmId) || vmClass == null) return null;
 
 		PsiClass currentClass = vmClass;
+		PsiSubstitutor currentSubst = PsiSubstitutor.EMPTY;
 		for (int i = 1; i < segments.length; i++) {
 			PsiMethod getter = findGetter(currentClass, segments[i]);
 			if (getter == null) return null;
-			PsiType returnType = getter.getReturnType();
+			PsiType returnType = substituteReturnType(currentClass, currentSubst, getter);
 			if (returnType == null) return null;
+			currentSubst = substitutorOf(returnType);
 			currentClass = resolveTypeToClass(returnType, context);
 			if (currentClass == null) return null;
 		}
@@ -462,6 +472,69 @@ public class ZulDomUtil {
 		}
 		return JavaPsiFacade.getInstance(context.getProject())
 				.findClass(canonicalText, GlobalSearchScope.allScope(context.getProject()));
+	}
+
+	/**
+	 * Returns the return type of {@code method} as seen through {@code owner}, i.e.
+	 * with the type parameters declared on {@code method}'s class replaced by the type
+	 * arguments that {@code owner} (parameterised by {@code ownerSubstitutor}) binds for
+	 * them.
+	 * <p>
+	 * This is what makes an inherited generic getter resolve to a concrete type. For a
+	 * ViewModel {@code FooVM extends GenericVM<Entity>} where {@code GenericVM<T>}
+	 * declares {@code T getModel()}, calling this with {@code owner = FooVM} yields
+	 * {@code Entity} instead of the bare type variable {@code T} — so a chained binding
+	 * such as {@code vm.model.someProperty} can keep resolving past {@code model}.
+	 * <p>
+	 * Falls back to the raw (unsubstituted) return type when the hierarchy cannot be
+	 * analysed, so behaviour never regresses below the previous text-based resolution.
+	 *
+	 * @return the (possibly substituted) return type, or {@code null} if the method has
+	 *         no return type
+	 */
+	@Nullable
+	public static PsiType substituteReturnType(@Nullable PsiClass owner,
+	                                           @Nullable PsiSubstitutor ownerSubstitutor,
+	                                           @Nullable PsiMethod method) {
+		if (method == null) return null;
+		PsiType raw = method.getReturnType();
+		if (raw == null) return null;
+		PsiClass declaring = method.getContainingClass();
+		if (owner == null || declaring == null) return raw;
+		PsiSubstitutor base = ownerSubstitutor != null ? ownerSubstitutor : PsiSubstitutor.EMPTY;
+		try {
+			PsiSubstitutor substitutor = declaring.equals(owner)
+					? base
+					: TypeConversionUtil.getSuperClassSubstitutor(declaring, owner, base);
+			PsiType substituted = substitutor.substitute(raw);
+			return substituted != null ? substituted : raw;
+		} catch (RuntimeException e) {
+			// Hierarchy not analysable (e.g. unrelated classes or test mocks) — be
+			// conservative and keep the raw type rather than dropping resolution.
+			return raw;
+		}
+	}
+
+	/**
+	 * Returns the substitutor that resolves the type parameters of {@code type}'s class
+	 * (for arrays, of the component type), so the next segment of a binding chain can be
+	 * resolved with the correct type arguments. Returns {@link PsiSubstitutor#EMPTY} when
+	 * {@code type} is not a class type or cannot be resolved.
+	 */
+	@NotNull
+	public static PsiSubstitutor substitutorOf(@Nullable PsiType type) {
+		PsiType deep = type != null ? type.getDeepComponentType() : null;
+		if (deep instanceof PsiClassType) {
+			try {
+				PsiClassType.ClassResolveResult result = ((PsiClassType) deep).resolveGenerics();
+				if (result != null && result.getSubstitutor() != null) {
+					return result.getSubstitutor();
+				}
+			} catch (RuntimeException ignored) {
+				// fall through to EMPTY
+			}
+		}
+		return PsiSubstitutor.EMPTY;
 	}
 
 	/**

--- a/src/main/java/org/zkoss/zkidea/reference/ZkBindingReferenceProvider.java
+++ b/src/main/java/org/zkoss/zkidea/reference/ZkBindingReferenceProvider.java
@@ -12,6 +12,8 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.PsiReferenceProvider;
+import com.intellij.psi.PsiSubstitutor;
+import com.intellij.psi.PsiType;
 import com.intellij.psi.xml.XmlAttributeValue;
 import com.intellij.psi.xml.XmlTag;
 import com.intellij.util.ProcessingContext;
@@ -353,6 +355,7 @@ public class ZkBindingReferenceProvider extends PsiReferenceProvider {
         // Walk property/method segments — text ranges cover only the identifier name,
         // excluding any parenthesized arguments so only the method name is clickable.
         PsiClass currentClass = vmClass;
+        PsiSubstitutor currentSubst = PsiSubstitutor.EMPTY;
         for (int i = 1; i < segments.size(); i++) {
             ChainSegment seg = segments.get(i);
             int segStart = bodyOffsetInElement + seg.nameStartInBody;
@@ -360,18 +363,20 @@ public class ZkBindingReferenceProvider extends PsiReferenceProvider {
             references.add(new ViewModelPropertyReference(
                     element, propRange, currentClass, seg.name, isCommandContext));
 
-            // Resolve type for the next segment
-            currentClass = resolvePropertyType(currentClass, seg.name, element);
+            // Resolve the owner class for the next segment, carrying the generic type
+            // arguments so that properties reached through an inherited generic getter
+            // (e.g. T getModel() declared in a generic base) keep resolving.
+            PsiMethod method = currentClass != null
+                    ? ZulDomUtil.findGetterOrMethod(currentClass, seg.name) : null;
+            if (method == null) {
+                LOG.debug("processChain: no getter or method for '" + seg.name + "'");
+                currentClass = null;
+                currentSubst = PsiSubstitutor.EMPTY;
+                continue;
+            }
+            PsiType nextType = ZulDomUtil.substituteReturnType(currentClass, currentSubst, method);
+            currentSubst = ZulDomUtil.substitutorOf(nextType);
+            currentClass = ZulDomUtil.resolveTypeToClass(nextType, element);
         }
-    }
-
-    private PsiClass resolvePropertyType(PsiClass ownerClass, String property, PsiElement context) {
-        if (ownerClass == null) return null;
-        PsiMethod method = ZulDomUtil.findGetterOrMethod(ownerClass, property);
-        if (method == null) {
-            LOG.debug("resolvePropertyType: no getter or method for '" + property + "'");
-            return null;
-        }
-        return ZulDomUtil.resolveTypeToClass(method.getReturnType(), context);
     }
 }

--- a/src/test/java/org/zkoss/zkidea/reference/ViewModelGenericInheritanceResolutionTest.java
+++ b/src/test/java/org/zkoss/zkidea/reference/ViewModelGenericInheritanceResolutionTest.java
@@ -1,0 +1,96 @@
+package org.zkoss.zkidea.reference;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiReference;
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase;
+
+/**
+ * IntelliJ Platform test for resolving ViewModel binding chains whose intermediate
+ * getter is inherited from a <em>generic</em> base class.
+ *
+ * <h3>Why BasePlatformTestCase</h3>
+ * The behaviour under test is generic type-argument substitution across an inheritance
+ * chain ({@code TypeConversionUtil.getSuperClassSubstitutor}). That cannot be reproduced
+ * with Mockito mocks of {@code PsiClass}/{@code PsiType}; it needs real PSI built from
+ * actual Java sources, which {@code BasePlatformTestCase} provides (with the
+ * {@code com.intellij.java} plugin loaded).
+ *
+ * <h3>Scenario</h3>
+ * <pre>
+ *   class CrewModel        { String getName(); }
+ *   abstract class GenericVM&lt;T&gt; { T getModel(); }     // getter declared on the generic base
+ *   class CrewVM extends GenericVM&lt;CrewModel&gt; { }      // binds T = CrewModel
+ * </pre>
+ * In the ZUL, {@code @load(vm.model.name)} must resolve {@code name} to
+ * {@code CrewModel.getName()}: {@code getModel()} returns the type variable {@code T},
+ * which is bound to {@code CrewModel} by {@code CrewVM}.
+ *
+ * <p>Before the fix the chain walker read {@code getModel()}'s return type as the bare
+ * type variable {@code T}, failed to resolve it to a class, and reported {@code name}
+ * (and everything after {@code model}) as unresolved (red). Feature file:
+ * {@code binding_property_navigation.feature}.
+ */
+public class ViewModelGenericInheritanceResolutionTest extends LightJavaCodeInsightFixtureTestCase {
+
+    private void addViewModelHierarchy() {
+        myFixture.addClass(
+                "package com.example;\n" +
+                "public class CrewModel {\n" +
+                "    public String getName() { return null; }\n" +
+                "}\n");
+        myFixture.addClass(
+                "package com.example;\n" +
+                "public abstract class GenericVM<T> {\n" +
+                "    public T getModel() { return null; }\n" +
+                "}\n");
+        myFixture.addClass(
+                "package com.example;\n" +
+                "public class CrewVM extends GenericVM<CrewModel> {\n" +
+                "}\n");
+    }
+
+    /**
+     * {@code vm.model.name} resolves to {@code CrewModel.getName()} even though
+     * {@code getModel()} is inherited from {@code GenericVM<T>} and returns the
+     * type variable {@code T} (bound to {@code CrewModel} by {@code CrewVM}).
+     */
+    public void testInheritedGenericGetterResolvesConcreteElementProperty() {
+        addViewModelHierarchy();
+        myFixture.configureByText("test.zul",
+                "<div apply=\"org.zkoss.bind.BindComposer\"\n" +
+                "     viewModel=\"@id('vm') @init('com.example.CrewVM')\">\n" +
+                "  <label value=\"@load(vm.model.na<caret>me)\"/>\n" +
+                "</div>\n");
+
+        PsiReference ref = myFixture.getReferenceAtCaretPosition();
+        assertNotNull("expected a reference on the 'name' segment", ref);
+
+        PsiElement target = ref.resolve();
+        assertNotNull(
+                "vm.model.name must resolve: getModel() returns T, bound to CrewModel "
+                        + "via CrewVM extends GenericVM<CrewModel>, so name -> CrewModel.getName()",
+                target);
+        assertTrue("resolved target should be a method", target instanceof PsiMethod);
+        assertEquals("getName", ((PsiMethod) target).getName());
+    }
+
+    /**
+     * A genuinely non-existent property on the substituted concrete type still does
+     * NOT resolve — the diagnostic red highlight is intentionally preserved so that
+     * unsupported bindings remain visible.
+     */
+    public void testUnknownPropertyOnSubstitutedTypeStaysUnresolved() {
+        addViewModelHierarchy();
+        myFixture.configureByText("test.zul",
+                "<div apply=\"org.zkoss.bind.BindComposer\"\n" +
+                "     viewModel=\"@id('vm') @init('com.example.CrewVM')\">\n" +
+                "  <label value=\"@load(vm.model.bo<caret>gus)\"/>\n" +
+                "</div>\n");
+
+        PsiReference ref = myFixture.getReferenceAtCaretPosition();
+        assertNotNull("expected a reference on the 'bogus' segment", ref);
+        assertNull("vm.model.bogus must remain unresolved — CrewModel has no getBogus()",
+                ref.resolve());
+    }
+}


### PR DESCRIPTION
Fixes #61.

## Problem

A `.zul` MVVM binding chain that passes through a getter whose return type is a **type
variable inherited from a generic base class** is reported as unresolved (red) from that
segment onward.

```java
class CrewModel              { public String getName() { ... } }
abstract class GenericVM<T>  { public T getModel() { ... } }   // getter on the generic base
class CrewVM extends GenericVM<CrewModel> { }                  // binds T = CrewModel
```

```xml
<label value="@load(vm.model.name)"/>   <!-- `name` was red -->
```

`vm.model` resolves (the inherited `getModel()` is found via `getAllMethods()`), but the
chain walker reads its return type as the bare type variable `T`, which
`resolveTypeToClass()` cannot map to a class, so the owner for `name` becomes `null`.
No generic type-argument substitution was performed across the inheritance chain.

## Fix

- Add `ZulDomUtil.substituteReturnType(owner, ownerSubstitutor, method)` — substitutes the
  getter's declared return type through the receiver's type arguments using
  `TypeConversionUtil.getSuperClassSubstitutor`, so `T` becomes the concrete type argument
  bound by the ViewModel (`CrewModel`).
- Add `ZulDomUtil.substitutorOf(type)` — carries the resolved substitutor to the next chain
  segment so deeper generic chains keep resolving.
- Use both in `ZkBindingReferenceProvider` (navigation / unresolved-reference highlighting)
  and the `ZulDomUtil` chain walkers (`resolveChainElementType` / `resolveChainFinalType`,
  used for collection-element and model type inference).
- Falls back to the raw return type when the hierarchy cannot be analysed, so resolution
  never regresses below the previous behaviour.

## Tests

- New `ViewModelGenericInheritanceResolutionTest` (real-PSI `LightJavaCodeInsightFixtureTestCase`):
  - `vm.model.name` resolves to `CrewModel.getName()` through the inherited generic getter.
  - a non-existent property (`vm.model.bogus`) stays unresolved (diagnostic red preserved).
- Full suite green: 275 tests, 0 failures.

## Docs

Added a "Generic type substitution" subsection to
`doc/data_binding_navigation_completion.md`.